### PR TITLE
fix pdfium repack 118.0.5868

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+aggregate_check: false
+upload_channels:
+  - boldorider4-test-channel
+channels:
+  - boldorider4-test-channel

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,12 +1,19 @@
 # Copy over the files in include and lib dirs
-for dir in "include" "include/cpp" "lib"
+# default permissions set to 644 for static files
+for dir in "include" "include/cpp"
 do
-    for filename in $(basename $(find ${SRC_DIR}/${dir} -type f -maxdepth 1) || exit 1)
+    for filepath in $(find ${SRC_DIR}/${dir} -type f -maxdepth 1 || exit 1)
     do
-        install -d ${PREFIX}/${dir} && \
-        install -v -m644 ${SRC_DIR}/${dir}/${filename} ${PREFIX}/${dir}/${filename} || \
-        exit 1
+        FILENAME=$(basename ${filepath})
+        install -d ${PREFIX}/${dir} && install -v -m644 ${filepath} ${PREFIX}/${dir}/${FILENAME} || exit 1
     done
+done
+
+# default permissions set to 755 for binary files
+for filepath in $(find ${SRC_DIR}/lib -type f -maxdepth 1 || exit 1)
+do
+    FILENAME=$(basename ${filepath})
+    install -d ${PREFIX}/lib && install -v -m755 ${filepath} ${PREFIX}/lib/${FILENAME} || exit 1
 done
 
 exit 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,11 +35,40 @@ build:
     - /lib64/ld-linux-aarch64.so.1  # [linux and aarch64]
     - /lib64/ld-linux-x86-64.so.2   # [linux and x86_64]
 
+{% set headers = [
+    "fpdf_annot.h",
+    "fpdf_attachment.h",
+    "fpdf_catalog.h",
+    "fpdf_dataavail.h",
+    "fpdf_doc.h",
+    "fpdf_edit.h",
+    "fpdf_ext.h",
+    "fpdf_flatten.h",
+    "fpdf_formfill.h",
+    "fpdf_fwlevent.h",
+    "fpdf_javascript.h",
+    "fpdf_ppo.h",
+    "fpdf_progressive.h",
+    "fpdf_save.h",
+    "fpdf_searchex.h",
+    "fpdf_signature.h",
+    "fpdf_structtree.h",
+    "fpdf_sysfontinfo.h",
+    "fpdf_text.h",
+    "fpdf_thumbnail.h",
+    "fpdf_transformpage.h",
+    "fpdfview.h"
+] %}
+
 test:
   commands:
-    - test -f $PREFIX/lib/libpdfium.dylib  # [osx]
-    - test -f $PREFIX/lib/libpdfium.so  # [linux]
+    - test -f $PREFIX/lib/libpdfium.dylib                  # [osx]
+    - test -f $PREFIX/lib/libpdfium.so                     # [linux]
     - if not exist "%LIBRARY_LIB%\\pdfium.dll.lib" exit 1  # [win]
+    {% for each_header in headers %}
+    - test -f "${PREFIX}/include/{{ each_header }}"        # [osx or linux]
+    - if not exist "%INCLUDE%\\{{ each_header }}" exit 1   # [win]
+    {% endfor %}
 
 about:
   home: https://github.com/bblanchon/pdfium-binaries

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
   fn: {{ name }}-{{ version }}-win-64.tgz                                                                                     # [win]
 
 build:
-  number: 0
+  number: 1
   skip: True  # [linux and (s390x or ppc64le)]
   missing_dso_whitelist:            # [linux]
     - /lib64/libpthread.so.0        # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,21 +7,21 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/bblanchon/{{ name }}/releases/download/chromium%2F{{ patch }}/{{ name.split('-')[0] }}-v8-mac-arm64.tgz  # [osx and arm64]
+  url: https://github.com/bblanchon/{{ name }}/releases/download/chromium%2F{{ patch }}/{{ name.split('-')[0] }}-mac-arm64.tgz  # [osx and arm64]
   sha256: 60a6d07bb5ff672fe43601e9b2b21e0859f645b3c22bd7f29a2fa664df1daa09                                                         # [osx and arm64]
-  fn: {{ name }}-v8-{{ version }}-osx-arm64.tgz                                                                                    # [osx and arm64]
-  url: https://github.com/bblanchon/{{ name }}/releases/download/chromium%2F{{ patch }}/{{ name.split('-')[0] }}-v8-mac-x64.tgz  # [osx and x86_64]
+  fn: {{ name }}-{{ version }}-osx-arm64.tgz                                                                                    # [osx and arm64]
+  url: https://github.com/bblanchon/{{ name }}/releases/download/chromium%2F{{ patch }}/{{ name.split('-')[0] }}-mac-x64.tgz  # [osx and x86_64]
   sha256: bfc88f6208cf7016e8e24db3e7c72da0ecb34c8454c45aa7a2899ac5ef0e2cc0                                                       # [osx and x86_64]
-  fn: {{ name }}-v8-{{ version }}-osx-64.tgz                                                                                     # [osx and x86_64]
-  url: https://github.com/bblanchon/{{ name }}/releases/download/chromium%2F{{ patch }}/{{ name.split('-')[0] }}-v8-linux-x64.tgz  # [linux and x86_64]
+  fn: {{ name }}-{{ version }}-osx-64.tgz                                                                                     # [osx and x86_64]
+  url: https://github.com/bblanchon/{{ name }}/releases/download/chromium%2F{{ patch }}/{{ name.split('-')[0] }}-linux-x64.tgz  # [linux and x86_64]
   sha256: 50e2fdb88e9ca56f61ffe8720c8a5b9327fbf06e7f5c740a9ea3f023e2b6b053                                                         # [linux and x86_64]
-  fn: {{ name }}-v8-{{ version }}-linux-64.tgz                                                                                     # [linux and x86_64]
-  url: https://github.com/bblanchon/{{ name }}/releases/download/chromium%2F{{ patch }}/{{ name.split('-')[0] }}-v8-linux-arm64.tgz  # [linux and aarch64]
+  fn: {{ name }}-{{ version }}-linux-64.tgz                                                                                     # [linux and x86_64]
+  url: https://github.com/bblanchon/{{ name }}/releases/download/chromium%2F{{ patch }}/{{ name.split('-')[0] }}-linux-arm64.tgz  # [linux and aarch64]
   sha256: dd4402f93b12da247cfd1f121bf6b4e5a0e585f912f1845351e207847925058a                                                           # [linux and aarch64]
-  fn: {{ name }}-v8-{{ version }}-linux-aarch64.tgz                                                                                  # [linux and aarch64]
-  url: https://github.com/bblanchon/{{ name }}/releases/download/chromium%2F{{ patch }}/{{ name.split('-')[0] }}-v8-win-x64.tgz  # [win]
+  fn: {{ name }}-{{ version }}-linux-aarch64.tgz                                                                                  # [linux and aarch64]
+  url: https://github.com/bblanchon/{{ name }}/releases/download/chromium%2F{{ patch }}/{{ name.split('-')[0] }}-win-x64.tgz  # [win]
   sha256: 97b1f488f6af20362f4b58d0c49e6a3d8af011631d7febceefc7ee168b29319d                                                       # [win]
-  fn: {{ name }}-v8-{{ version }}-win-64.tgz                                                                                     # [win]
+  fn: {{ name }}-{{ version }}-win-64.tgz                                                                                     # [win]
 
 build:
   number: 0


### PR DESCRIPTION
- the basic library that needs to be repacked in this version is not the `V8`, hence tarball URL has been adjusted
- the build script has been fixed as it did not include header files on linux
- the test section has been extended to ensure header files are also being packaged
- bumped build number