### PR TITLE
push pkg to custom channel

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40


### PR DESCRIPTION
This package should be pushed to a custom channel and then removed from main.
This would fulfill the upstream maintainer's [request](https://github.com/AnacondaRecipes/pdfium-binaries-feedstock/pull/7#issuecomment-1785928903) as well as our policies for individual dependencies of custom channel packages (in this case `pypdfium2`).